### PR TITLE
Use Correct Index For the First Byte of PM10

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PM1006K
-version=1.0.2
+version=1.0.3
 author=Kevin Lutzer <kevinlutzer@proton.me>
 maintainer=Kevin Lutzer <kevinlutzer@proton.me>
 sentence=Driver library for PM1006K sensors.

--- a/src/PM1006K.cpp
+++ b/src/PM1006K.cpp
@@ -65,7 +65,7 @@ bool PM1006K::takeMeasurement() {
   */
   this->_lastPM2_5 = (rxBuf[5] << 8) | rxBuf[6];
   this->_lastPM1_0 = (rxBuf[9] << 8) | rxBuf[10];
-  this->_lastPM10 = (rxBuf[13] << 8) | rxBuf[12];
+  this->_lastPM10 = (rxBuf[13] << 8) | rxBuf[14];
 
   return true;
 }


### PR DESCRIPTION
Fixes: https://github.com/kevinlutzer/Arduino-PM1006K/issues/2

I was indexing into the wrong position for the first byte of PM10 in the measurement buffer. 